### PR TITLE
Abeer: update the identity module's argument in the README.md usage examples.

### DIFF
--- a/modules/identity/README.md
+++ b/modules/identity/README.md
@@ -71,7 +71,7 @@ locals {
 }
 
 module "IAM" {
-  path = PATH_TO_MODULE
+  source = PATH_TO_MODULE
 
   tenant_id = "oci.xxxxxxxxx.xxxxxx"
   memberships = local.memberships
@@ -111,14 +111,14 @@ locals {
 }
 
 module "IAM" {
-  path = PATH_TO_MODULE
+  source = PATH_TO_MODULE
 
   tenant_id = "oci.xxxxxxxxx.xxxxxx"
   memberships = local.memberships
 }
 
 module "idp_mapping" {
-  path = PATH_TO_MODULE
+  source = PATH_TO_MODULE
 
   tenant_id = "oci.xxxxxxxxx.xxxxxx"
   identity_group_mapping = {
@@ -150,7 +150,7 @@ Service accounts are accounts that meant to used by machines. When a service acc
 
 ```h
 module "IAM" {
-  path = PATH_TO_MODULE
+  source = PATH_TO_MODULE
 
   tenant_id = "oci.xxxxxxxxx.xxxxxx"
   service_accounts = ["terraform-cli", "github-client"] # then using the service accout name, you can assign policy to the service account.
@@ -188,7 +188,7 @@ locals {
 }
 
 module "top_level_compartments" {
-  path = PATH_TO_MODULE
+  source = PATH_TO_MODULE
 
   tenant_id = local.tenant_id
 
@@ -210,7 +210,7 @@ module "top_level_compartments" {
 }
 
 module "child_compartments" {
-  path = PATH_TO_MODULE
+  source = PATH_TO_MODULE
 
   tenant_id = local.tenant_id
 
@@ -233,7 +233,7 @@ Some policies must be attached to the tenancy itself, but not to a compartment. 
 
 ```h
 module "tenancy_policies" {
-  path = PATH_TO_MODULE
+  source = PATH_TO_MODULE
 
   tenant_id = "oci.xxxxxxxxx.xxxxxx"
   tenancy_policies = {
@@ -282,7 +282,7 @@ locals {
 }
 
 module "main_iam" {
-  path = PATH_TO_MODULE
+  source = PATH_TO_MODULE
 
   tenant_id        = local.tenant_id
   memberships      = local.memberships
@@ -312,7 +312,7 @@ module "main_iam" {
 }
 
 module "child_compartments" {
-  path = PATH_TO_MODULE
+  source = PATH_TO_MODULE
 
   tenant_id = local.tenant_id
 

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,13 @@
+# v2.8.1:
+## **New**
+None
+
+## **Fix**
+* Correct `path` argument by `source` argument to specify the module path in `identity` module usage examples in `README.md`.
+  
+## _**Breaking Changes**_
+None
+
 # v2.8.0:
 ## **New**
 * `instances`: add new argument `availability_config`. for VM migration during infrastructure maintenance events


### PR DESCRIPTION
Module path specified by 'source' argument, which has the module path as a value.